### PR TITLE
Add ssh-port argument

### DIFF
--- a/transient/cli.py
+++ b/transient/cli.py
@@ -32,6 +32,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('-ssh-timeout', default=60, type=int,
                         help='Time to wait for SSH connection before failing')
 
+    parser.add_argument('-ssh-port', help='Local port the 22 of the guest is forwarded to')
+
     parser.add_argument('-sync-before', '-b', nargs='+', action='extend',
                         help='Sync a host path to a guest path before starting the guest')
 

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -41,11 +41,19 @@ class TransientVm:
             if self.config.ssh_console is True:
                 new_args.append("-nographic")
 
-            # Use userspace networking (so no root is needed), and bind
-            # the random localhost port to guest port 22
-            self.ssh_port = self.__allocate_random_port()
-            new_args.extend(["-net", "nic,model=e1000",
-                             "-net", "user,hostfwd=tcp::{}-:22".format(self.ssh_port)])
+            if self.config.ssh_port is None:
+                self.ssh_port = self.__allocate_random_port()
+            else:
+                self.ssh_port = self.config.ssh_port
+
+            # the random localhost port or the user provided port to guest port 22
+            new_args.extend([
+                "-netdev",
+                "user,id=transient-sshdev,hostfwd=tcp::{}-:22".format(self.ssh_port),
+                "-device",
+                "e1000,netdev=transient-sshdev"
+            ])
+
         return new_args
 
     def __allocate_random_port(self) -> int:


### PR DESCRIPTION
Add the ssh-port option and find an open port if there is no port given
instead of using a default value.