### PR TITLE
Add QMP client and clean shutdown

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -72,6 +72,10 @@ the default 22.
 - `-ssh-command COMMAND`: Instead of connecting standard input and output to the SSH
 connection with the virtual machine, pass `COMMAND` instead. (e.g., `ssh vagrant@vm-ip COMMAND`)
 
+- `-shutdown-timeout`: When the user exits an SSH console, `transient` sends an ACPI
+shutdown event and waits for this time for the guest to shutdown cleanly. After this
+timeout, the guest is terminated.
+
 - `-shared-folder FOLDERSPEC`: A `FOLDERSPEC` consists of two paths joined with a colon.
 For example `/path/on/host:/path/on/guest`. For additional information, see [Using
 Shared Folders](/examples/shared-folders/).

--- a/test/features/persist.feature
+++ b/test/features/persist.feature
@@ -1,0 +1,15 @@
+Feature: VM Persistence
+  In order to support test/dev senarios where disk persistence is
+  needed, transient can boot using the same disk multiple times.
+
+ Scenario: Reboot a VM keeping changes
+    Given a transient vm
+      And a name "test-vm"
+      And a frontend "./test-frontend"
+      And a disk image "generic/alpine38:v3.0.2"
+      And a ssh command "touch persist-is-working"
+     When the vm runs to completion
+      And a new ssh command "ls"
+      And the vm runs to completion
+     Then the return code is 0
+      And stdout contains "persist-is-working"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -6,7 +6,7 @@ from hamcrest import *
 # Wait for a while, as we may be downloading the image as well
 VM_WAIT_TIME=60 * 10
 if os.getenv("CI") is not None:
-    DEFAULT_TRANSIENT_ARGS = ["-ssh-timeout", "300"]
+    DEFAULT_TRANSIENT_ARGS = ["-ssh-timeout", "300", "-shutdown-timeout", "300"]
     DEFAULT_QEMU_ARGS = ["-m", "1G", "-smp", "2"]
 else:
     DEFAULT_TRANSIENT_ARGS = []
@@ -95,6 +95,7 @@ def step_impl(context):
     context.vm_config["ssh-with-serial"] = True
 
 @given('a ssh command "{command}"')
+@when('a new ssh command "{command}"')
 def step_impl(context, command):
     context.vm_config["ssh-command"] = command
 

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -65,6 +65,9 @@ def parse_arguments() -> argparse.Namespace:
     run_parser.add_argument('-sync-after', '-a', nargs='+', action=ExtendAction,
                             help='Sync a guest path to a host path after stopping the guest')
 
+    run_parser.add_argument('-shutdown-timeout', type=int, default=20,
+                            help='The time to wait for shutdown before terminating QEMU')
+
     run_parser.add_argument(
         '-shared-folder', '-s', nargs='+', action=ExtendAction, default=[],
         help='Share a host directory with the guest (/path/on/host:/path/on/guest)')

--- a/transient/qemu.py
+++ b/transient/qemu.py
@@ -1,16 +1,140 @@
+import collections
 import logging
 import fcntl
 import os
+import json
 import re
 import select
 import signal
+import socket
 import subprocess
 import sys
 import threading
+import time
 
-from typing import List, Optional
+from typing import Any, Dict, DefaultDict, List, Optional, Callable, Union
 
 from . import linux
+from . import utils
+
+_QMP_CONNECTION_TIMEOUT = 4
+_QMP_DELAY_BETWEEN = 0.2
+QMP_DEFAULT_SYNC_TIME = 5
+QmpMessage = Dict[Any, Any]
+QmpCallback = Callable[[QmpMessage], None]
+
+
+class QmpClient:
+    port: int
+    sock: socket.socket
+    id_callbacks: DefaultDict[int, List[QmpCallback]]
+    event_callbacks: DefaultDict[str, List[QmpCallback]]
+    current_id: int
+
+    def __init__(self, port: int):
+        self.port = port
+        self.id_callbacks = collections.defaultdict(list)
+        self.event_callbacks = collections.defaultdict(list)
+        self.current_id = 0
+
+    def __allocate_id(self) -> int:
+        ret = self.current_id
+        self.current_id += 1
+        return ret
+
+    def __send_msg(self, msg: QmpMessage):
+        logging.debug("Sending QMP message: {}".format(msg))
+        self.file.write((json.dumps(msg) + "\r\n").encode("utf-8"))
+        self.file.flush()
+
+    def connect(self):
+        logging.info("Connecting to QMP socket at localhost:{}".format(self.port))
+        start = time.time()
+        while time.time() - start < _QMP_CONNECTION_TIMEOUT:
+            try:
+                self.sock = socket.create_connection(("localhost", self.port))
+                logging.debug("QMP connection established")
+
+                # Make a file object so we can readline. QMP messages will always
+                # be newline delimited, so this gives us framing. Note that we
+                # cannot set the socket to be non-blocking if we do this.
+                self.file = self.sock.makefile("rwb")
+
+                # Go ahead and enable sending commands
+                self.__send_msg({
+                    "execute": "qmp_capabilities"
+                })
+
+                # Start and drop this reference. Because the thread is a daemon it will
+                # be killed when python dies
+                thread = threading.Thread(target=self.__start)
+                thread.daemon = True
+                thread.start()
+
+                return
+            except ConnectionRefusedError:
+                logging.debug("QMP connection refused. Waiting")
+                time.sleep(_QMP_DELAY_BETWEEN)
+        raise ConnectionRefusedError(
+            "Unable to connect to QMP socket at localhost:{}".format(self.port))
+
+    def __start(self):
+        while True:
+            msg_json = self.file.readline()
+            if msg_json is None or msg_json == b"":
+                logging.debug("QEMU closed QMP connection")
+                return
+            msg = json.loads(msg_json)
+            logging.debug("Received QMP message: {}".format(msg))
+            if "id" in msg:
+                for callback in self.id_callbacks[msg["id"]]:
+                    callback(msg)
+                # IDs should not be repeated, so clean up the callbacks
+                del self.id_callbacks[msg["id"]]
+            elif "event" in msg:
+                for callback in self.event_callbacks[msg["event"]]:
+                    callback(msg)
+
+    def send_async(self, msg: QmpMessage, callback: QmpCallback):
+        id = self.__allocate_id()
+        msg["id"] = id
+        self.register_callback(id, callback)
+        self.__send_msg(msg)
+
+    def send_sync(self, msg: QmpMessage,
+                  timeout: Optional[float] = QMP_DEFAULT_SYNC_TIME) -> QmpMessage:
+        response = None
+
+        # Start the semaphore value at zero to this thread will block. The callback
+        # will increment the counter to unblock this thread when the response to
+        # this message has been received.
+        semaphore = threading.Semaphore(value=0)
+
+        def _sync_callback(received: QmpMessage):
+            nonlocal response
+            response = received
+
+            # Note that we are 'releasing' a semaphore we have not acquired. This
+            # makes more sense if we using the posix semaphore terminology of 'wait'
+            # and 'post', which does not imply that this thread has previously
+            # 'acquired' the semaphore.
+            semaphore.release()
+
+        self.send_async(msg, _sync_callback)
+        semaphore.acquire(timeout=timeout)  # type: ignore
+
+        assert(response is not None)
+        return response
+
+    def register_callback(self, id_or_event: Union[int, str],
+                          callback: QmpCallback):
+        if isinstance(id_or_event, int):
+            self.id_callbacks[id_or_event].append(callback)
+        elif isinstance(id_or_event, str):
+            self.event_callbacks[id_or_event].append(callback)
+        else:
+            raise RuntimeError(
+                "Invalid argument to register_callback '{}'".format(id_or_event))
 
 
 class QemuOutputProxy:
@@ -27,6 +151,13 @@ class QemuOutputProxy:
         self.quiet = True
 
     def start(self, proc_handle: 'subprocess.Popen[bytes]'):
+        # Start and drop this reference. Because the thread is a daemon it will
+        # be killed when python dies
+        thread = threading.Thread(target=self.__start, args=(proc_handle,))
+        thread.daemon = True
+        thread.start()
+
+    def __start(self, proc_handle: 'subprocess.Popen[bytes]'):
         assert(proc_handle.stdout is not None)
 
         # Set the socket to be non-blocking, as we don't want to read in chuncks
@@ -83,6 +214,7 @@ class QemuRunner:
     args: List[str]
     quiet: bool
     proxy: Optional[QemuOutputProxy]
+    qmp_client: QmpClient
 
     # As far as I can tell, this _has_ to be quoted. Otherwise, it will
     # fail at runtime because I guess something is actually run here and
@@ -90,15 +222,21 @@ class QemuRunner:
     proc_handle: 'Optional[subprocess.Popen[bytes]]'
 
     def __init__(self, args: List[str], *, bin_name: Optional[str] = None,
-                 quiet: bool = False, silenceable: bool = False) -> None:
+                 qmp_port: Optional[int] = None, quiet: bool = False,
+                 silenceable: bool = False) -> None:
+        qmp_port = qmp_port or utils.allocate_random_port()
         self.bin_name = bin_name or self.__find_qemu_bin_name()
         self.quiet = quiet
-        self.args = args
+        self.args = self.__default_args(qmp_port) + args
         self.proc_handle = None
         self.proxy = None
+        self.qmp_client = QmpClient(qmp_port)
 
         if silenceable is True:
             self.proxy = QemuOutputProxy()
+
+    def __default_args(self, port) -> List[str]:
+        return ["-qmp", "tcp:localhost:{},server,nowait".format(port)]
 
     def __find_qemu_bin_name(self) -> str:
         return 'qemu-system-x86_64'
@@ -126,11 +264,7 @@ class QemuRunner:
             preexec_fn=lambda: linux.set_death_signal(signal.SIGTERM))
 
         if self.proxy is not None:
-            # Start and drop this reference. Because the thread is a daemon it will
-            # be killed when python dies
-            thread = threading.Thread(target=self.proxy.start, args=(self.proc_handle,))
-            thread.daemon = True
-            thread.start()
+            self.proxy.start(self.proc_handle)
         return self.proc_handle
 
     def silence(self):
@@ -141,23 +275,25 @@ class QemuRunner:
         else:
             raise RuntimeError("Attempt to silence QemuRunner that is not silenceable")
 
-    def wait(self) -> int:
+    def wait(self, timeout: Optional[int] = None) -> int:
         if self.proc_handle is None:
             raise RuntimeError("QemuRunner cannot wait without being started")
 
         logging.info("Waiting for qemu process to terminate")
-        self.proc_handle.wait()
+        self.proc_handle.wait(timeout=timeout)
         return self.proc_handle.returncode
 
     def terminate(self) -> None:
         if self.proc_handle is None:
             raise RuntimeError("QemuRunner cannot terminate without being started")
-        self.proc_handle.terminate()
+        if self.proc_handle.poll():
+            self.proc_handle.terminate()
 
     def kill(self) -> None:
         if self.proc_handle is None:
             raise RuntimeError("QemuRunner cannot be killed without being started")
-        self.proc_handle.kill()
+        if self.proc_handle.poll():
+            self.proc_handle.kill()
 
     def returncode(self) -> int:
         if self.proc_handle is None:

--- a/transient/utils.py
+++ b/transient/utils.py
@@ -1,6 +1,7 @@
 import distutils.util
+import socket
 
-from typing import Optional
+from typing import cast, Optional
 
 
 def prompt_yes_no(prompt: str, default: Optional[bool] = None) -> bool:
@@ -30,3 +31,15 @@ def format_bytes(size):
         size /= power
         n += 1
     return "{:.2f} {}".format(size, labels[n])
+
+
+def allocate_random_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    # Binding to port 0 causes the kernel to allocate a port for us. Because
+    # it won't reuse that port until is _has_ to, this can safely be used
+    # as (for example) the ssh port for the guest and it 'should' be race-free
+    s.bind(("", 0))
+    addr = s.getsockname()
+    s.close()
+    return cast(int, addr[1])


### PR DESCRIPTION
Fixes #43, #40

The logic here is that we establish a QMP connection and send an
ACPI shutdown request. We then wait a bit for the guest to shutdown
cleanly. If it doesn't, we SIGTERM QEMU and exit.

Return codes are handled in the following way:

If QEMU exits prior to SSH, we return with its exit code. Once the
SSH connection closes, we will always return the SSH exit code,
regardless of whether QEMU exits cleanly. This is mainly so the
`-shutdown-timeout=0` case has the effect of preserving the current
behavior. i.e., QEMU is sent SIGTERM (and therefore has a non-zero
exit code) but we get the SSH code which may be zero.

I went with this approach over just sshing in to the guest to send shutdown
because I would ultimately like to find a way to flush whatever write cache
QEMU is keeping so we can just SIGTERM. There isn't really any reason I can
see that QEMU guests should be _more_ susceptible to corruption than 
a real guest, if the sync stuff is being done correctly. I suspect any way to
flush that cache would be done via QMP. Also, this way we don't need to spend
time doing the SSH again, and it should work on pretty much any guest.