### PR TITLE
Implement directory synchronization

### DIFF
--- a/.github/workflows/transient.yml
+++ b/.github/workflows/transient.yml
@@ -40,7 +40,7 @@ jobs:
         python3 -m pip install -e '.[dev]'
     - name: Run tests
       run: |
-        make test-ci
+        make test-docker-ci
 
   Test-Multi-Python:
     runs-on: ubuntu-18.04
@@ -52,7 +52,7 @@ jobs:
     - name: Install package dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install ssh qemu
+        sudo apt-get install ssh qemu libguestfs-tools
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -63,4 +63,5 @@ jobs:
         python -m pip install -e '.[dev]'
     - name: Run tests
       run: |
+        sudo chmod +r /boot/vmlinuz-*
         make test-ci

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ transient/vagrant_keys/__pycache__/
 transient.egg-info/
 build/
 dist/
-test/test-backend/
-test/test-frontend/
+
+# artifacts produced from testing
+artifacts

--- a/README.md
+++ b/README.md
@@ -61,3 +61,13 @@ transient run \
 
 The `-ssh-console` flag depends on the image having the normal vagrant keypair
 trusted for the `vagrant` user.
+
+Using `-copy-in-before` and `-copy-out-after`
+---------------------------------------------
+
+Ubuntu does not support these flags by default because the kernel is not readable by non-root users.
+To use these flags on Ubuntu, allow non-root users to read the kernel by executing:
+
+```
+sudo chmod +r /boot/vmlinuz-*
+```

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,4 +22,4 @@ behave-ci:
 
 .PHONY: clean
 clean:
-	rm -rf test-frontend test-backend
+	rm -rf artifacts

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,9 +5,16 @@ all: | clean behave
 .PHONY: ci
 ci: behave-ci
 
+.PHONY: docker-ci
+docker-ci: docker-behave-ci
+
 .PHONY: behave
 behave:
 	behave
+
+.PHONY: docker-behave-ci
+docker-behave-ci:
+	behave --tags=~@skip-in-docker-ci --tags=~@skip-in-ci
 
 .PHONY: behave-ci
 behave-ci:

--- a/test/features/copy-in-copy-out.feature
+++ b/test/features/copy-in-copy-out.feature
@@ -1,0 +1,39 @@
+@skip-in-docker-ci
+Feature: Copy-in and Copy-out Support
+    In order to facilitate easier file transfer between the host and guest,
+    transient supports copy-in and copy-out support. Given a path on the host and an
+    absolute path on the VM, transient can:
+    - copy the host file or directory to the guest directory before starting the VM
+    - copy the guest file or directory to the host directory after stopping the VM
+
+ Scenario: Download a single image
+    Given a transient vm
+      And a name "test-vm"
+      And a disk image "generic/alpine38:v3.0.2"
+      And the vm is prepare-only
+     When the transient command is run
+     Then the return code is 0
+
+  Scenario: Copy in directory before starting VM
+    Given a transient vm
+      And a name "test-vm"
+      And a disk image "generic/alpine38:v3.0.2"
+      And a test file: "artifacts/copy-in-before-test-file"
+      And a guest directory: "/home/vagrant/"
+      And the test file is copied to the guest directory before starting
+      And a ssh command "ls /home/vagrant"
+     When the vm runs to completion
+     Then the return code is 0
+      And stdout contains "copy-in-before-test-file"
+
+  Scenario: Copy out directory after stopping VM
+    Given a transient vm
+      And a name "test-vm"
+      And a disk image "generic/alpine38:v3.0.2"
+      And a host directory: "artifacts/"
+      And a guest test file: "/home/vagrant/copy-out-after-test-file"
+      And the guest test file is copied to the host directory after stopping
+      And a ssh command "touch /home/vagrant/copy-out-after-test-file"
+     When the vm runs to completion
+     Then the return code is 0
+      And the file "artifacts/copy-out-after-test-file" exists

--- a/test/features/images.feature
+++ b/test/features/images.feature
@@ -15,7 +15,7 @@ Feature: Image Support
     Given a transient vm
       And a name "test-vm"
       And a disk image "generic/alpine38:v3.0.2"
-      And a frontend "./test-frontend"
+      And a frontend "./artifacts/test-frontend"
       And the vm is prepare-only
      When the transient command is run
      Then the return code is 0
@@ -25,7 +25,7 @@ Feature: Image Support
     Given a transient vm
       And a name "test-vm"
       And a disk image "generic/alpine38:v3.0.2"
-      And a backend "./test-backend"
+      And a backend "./artifacts/test-backend"
       And the vm is prepare-only
      When the transient command is run
      Then the return code is 0
@@ -34,7 +34,7 @@ Feature: Image Support
  Scenario: Delete a frontend image
     Given a transient delete command
       And a name "test-vm"
-      And a frontend "./test-frontend"
+      And a frontend "./artifacts/test-frontend"
      When the transient command is run
      Then the return code is 0
       And the file "test%2Dvm-0-generic%2Falpine38%3Av3.0.2" is not in the frontend
@@ -42,7 +42,7 @@ Feature: Image Support
  Scenario: Delete a backend image
     Given a transient delete command
       And a disk image "generic/alpine38:v3.0.2"
-      And a backend "./test-backend"
+      And a backend "./artifacts/test-backend"
      When the transient command is run
      Then the return code is 0
       And the file "generic%2Falpine38%3Av3.0.2" is not in the backend
@@ -50,6 +50,6 @@ Feature: Image Support
  Scenario: Delete a nonexistent file
     Given a transient delete command
       And a disk image "backend-does-not-exist"
-      And a backend "./test-backend"
+      And a backend "./artifacts/test-backend"
      When the transient command is run
      Then the return code is 1

--- a/test/features/persist.feature
+++ b/test/features/persist.feature
@@ -5,7 +5,7 @@ Feature: VM Persistence
  Scenario: Reboot a VM keeping changes
     Given a transient vm
       And a name "test-vm"
-      And a frontend "./test-frontend"
+      And a frontend "./artifacts/test-frontend"
       And a disk image "generic/alpine38:v3.0.2"
       And a ssh command "touch persist-is-working"
      When the vm runs to completion

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -4,8 +4,6 @@ import subprocess
 from behave import *
 from hamcrest import *
 
-PATH_TO_IMAGE_STORE = f'{os.environ["HOME"]}/.local/share/transient/'
-
 # Wait for a while, as we may be downloading the image as well
 VM_WAIT_TIME=60 * 10
 if os.getenv("CI") is not None:
@@ -32,9 +30,6 @@ def wait_on_vm(context, timeout=VM_WAIT_TIME):
     context.handle.wait(timeout)
     context.stdout = context.handle.stdout.read().decode('utf-8')
     context.stderr = context.handle.stderr.read().decode('utf-8')
-
-def get_deepest_directory_name(directory):
-    return directory.split('/')[-2]
 
 @given('a transient vm')
 def step_impl(context):
@@ -95,26 +90,34 @@ def step_impl(context, mount):
 def step_impl(context, flag):
     context.vm_config["transient-args"].append(flag)
 
+@given('a guest test file: "{}"')
 @given('a guest directory: "{}"')
-def step_impl(context, guest_directory):
-    context.vm_config["guest-directory"] = guest_directory
+def step_impl(context, guest_path):
+    context.vm_config["guest-path"] = guest_path
+
+@given('a test file: "{}/{}"')
+def step_impl(context, host_directory, test_file_name):
+    os.makedirs(host_directory, exist_ok=True)
+    test_file_path = os.path.join(host_directory, test_file_name)
+    open(test_file_path, 'w').close()
+    context.vm_config["test-file"] = test_file_path
 
 @given('a host directory: "{}"')
 def step_impl(context, host_directory):
     context.vm_config["host-directory"] = host_directory
     os.makedirs(host_directory, exist_ok=True)
 
-@given('the host directory is copied to the guest directory before starting')
+@given('the test file is copied to the guest directory before starting')
 def step_impl(context):
     directory_mapping = '{}:{}'.format(
-            context.vm_config['host-directory'],
-            context.vm_config['guest-directory'])
+            context.vm_config['test-file'],
+            context.vm_config['guest-path'])
     context.vm_config["transient-args"].extend(["-copy-in-before", directory_mapping])
 
-@given('the guest directory is copied to the host directory after stopping')
+@given('the guest test file is copied to the host directory after stopping')
 def step_impl(context):
     directory_mapping = '{}:{}'.format(
-            context.vm_config['guest-directory'],
+            context.vm_config['guest-path'],
             context.vm_config['host-directory'])
     context.vm_config["transient-args"].extend(["-copy-out-after", directory_mapping])
 
@@ -175,32 +178,6 @@ def step_impl(context, name):
     items = os.listdir(context.vm_config["image-frontend"])
     assert_that(items, not_(has_item(name)))
 
-@then('the host directory exists in the guest directory')
-def step_impl(context):
-
-    guest_directory = context.vm_config['guest-directory']
-    mirrored_guest_directory = os.path.join('artifacts', 'guest')
-    os.makedirs(mirrored_guest_directory, exist_ok=True)
-
-    image_path = os.path.join(PATH_TO_IMAGE_STORE,'test-vm-0-generic_alpine38_v3.0.2')
-
-    subprocess.check_output(['virt-copy-out',
-            '-a', image_path,
-             guest_directory,
-             mirrored_guest_directory])
-
-    host_directory = context.vm_config['host-directory']
-    host_directory = get_deepest_directory_name(host_directory)
-    guest_directory = get_deepest_directory_name(guest_directory)
-    copied_host_directory = os.path.join(mirrored_guest_directory, guest_directory, host_directory)
-
-    assert os.path.exists(copied_host_directory)
-
-@then('the guest directory exists in the host directory')
-def step_impl(context):
-    host_directory = context.vm_config['host-directory']
-    guest_directory = context.vm_config['guest-directory']
-    guest_directory = get_deepest_directory_name(guest_directory)
-    copied_guest_directory = os.path.join(host_directory, guest_directory)
-
-    assert os.path.exists(copied_guest_directory)
+@then('the file "{file_path}" exists')
+def step_impl(context, file_path):
+    assert os.path.exists(file_path)

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -94,6 +94,12 @@ class TransientOptionParser(click.parser.OptionParser):
 
 @click.help_option('-h', '--help')
 @with_common_options
+@click.option('-copy-in-before', '-b', multiple=True,
+              help='Copy a file or directory into the VM before running ' + \
+              '(path/on/host:/absolute/path/on/guest)')
+@click.option('-copy-out-after', '-a', multiple=True,
+              help='Copy a file or directory out of the VM after running ' + \
+              '(/absolute/path/on/VM:path/on/host)')
 @click.option('-name', help='Delete images associated with the given vm name', required=True)
 @click.option('-ssh-console', '-ssh', is_flag=True,
               help='Use an ssh connection instead of the serial console')

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -95,10 +95,10 @@ class TransientOptionParser(click.parser.OptionParser):
 @click.help_option('-h', '--help')
 @with_common_options
 @click.option('-copy-in-before', '-b', multiple=True,
-              help='Copy a file or directory into the VM before running ' + \
+              help='Copy a file or directory into the VM before running ' +
               '(path/on/host:/absolute/path/on/guest)')
 @click.option('-copy-out-after', '-a', multiple=True,
-              help='Copy a file or directory out of the VM after running ' + \
+              help='Copy a file or directory out of the VM after running ' +
               '(/absolute/path/on/VM:path/on/host)')
 @click.option('-name', help='Delete images associated with the given vm name', required=True)
 @click.option('-ssh-console', '-ssh', is_flag=True,


### PR DESCRIPTION
This PR adds the `-copy-in-before` and `-copy-out-after` feature. Passing tests are included in this PR.

A few concerns:
I had to add: `PATH_TO_IMAGE_STORE = f'{os.environ["HOME"]}/.local/share/transient/'` in `steps.py` because I needed a way to access the image path. I'm not sure if this is the cleanest way.
This is a nitpick but there doesn't seem to be consistent use of single and double quotes for python strings. I'm hoping this is taken care of when the black formatter is added.