### PR TITLE
5 add config file support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ setup(
         "beautifultable==0.8.0",
         "click==7.1.2",
         "importlib-resources==1.5.0",
+        "marshmallow==3.6.1",
         "progressbar2==3.51.3",
-        "requests==2.23.0"
+        "requests==2.23.0",
+        "toml==0.10.1",
     ],
     extras_require={
         "dev": [

--- a/test/config-files/exhaustive-config
+++ b/test/config-files/exhaustive-config
@@ -1,0 +1,65 @@
+# A Transient config file
+
+#
+# Transient arguments are set in a similar manner compared to the command line.
+# A few differences exist:
+#
+#   1. All values are set using an equal sign:
+#
+#          shutdown-timeout = 20
+#
+#
+#   2. Strings are encapsulated with double quotes
+#
+#          name = "vm_name"
+#
+#
+#   3. Flags are set to Booleans:
+#
+#          prepare-only = true
+#          ssh-console = false
+#
+#
+#   4. Lists are encapsulated by square brackets:
+#
+#          shared-folder = [
+#              "/path/on/host:/path/on/guest",
+#              "/path/on/host2:/path/on/guest2"
+#          ]
+#
+
+[transient]
+
+copy-in-before   = []
+copy-out-after   = []
+copy-timeout     = 0
+image            = ["centos/7:2004.01"]
+# image_backend    = None
+# image_frontend   = None
+# name             = None
+prepare-only     = true
+qmp-timeout      = 10
+shared-folder    = []
+shutdown-timeout = 20
+# ssh-bin-name     = None
+# ssh-command      = None
+ssh-console      = false
+ssh-port         = 22
+# ssh-user         = None
+ssh-with-serial  = false
+
+
+#
+# QEMU arguments are set in a similar manner compared to the command line.
+#
+# The only difference is that the QEMU argument string is split by whitespace
+# and encapsulated in a list.
+#
+
+[qemu]
+
+qemu-args = [
+    "-nographic",
+    "-enable-kvm",
+    "-m", "1G"
+]

--- a/test/config-files/invalid-config
+++ b/test/config-files/invalid-config
@@ -1,0 +1,5 @@
+[transient]
+ssh-foobar = true
+
+[qemu]
+qemu-args = []

--- a/test/config-files/multiple-verbose-flags-config
+++ b/test/config-files/multiple-verbose-flags-config
@@ -1,0 +1,6 @@
+[transient]
+image = ["generic/alpine38:v3.0.2"]
+prepare-only = true
+
+[qemu]
+qemu-args = []

--- a/test/config-files/ssh-command-config
+++ b/test/config-files/ssh-command-config
@@ -1,0 +1,6 @@
+[transient]
+image = ["generic/alpine38:v3.0.2"]
+ssh-command = "echo 'ssh-command working'"
+
+[qemu]
+qemu-args = []

--- a/test/features/config_file.feature
+++ b/test/features/config_file.feature
@@ -1,0 +1,26 @@
+Feature: Configuration File
+  In order to facilitate easier usage, prevent long argument strings, and
+  promote consistent configuration sharing, Transient supports configuration
+  files.
+
+Scenario: Invalid config file
+   Given a transient vm
+     And the config file "invalid-config"
+    When the transient command is run
+    Then the return code is 1
+     And stderr contains "Invalid option on line"
+
+Scenario: Run VM with a single SSH command
+   Given a transient vm
+     And the config file "ssh-command-config"
+    When the vm runs to completion
+    Then the return code is 0
+     And stdout contains "ssh-command working"
+
+Scenario: Multiple verbose flags are supported
+   Given a transient vm
+     And the config file "multiple-verbose-flags-config"
+     And a transient early flag "-vvv"
+    When the transient command is run
+    Then the return code is 0
+     And stderr contains "INFO"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -160,6 +160,12 @@ def step_impl(context, flag):
     context.vm_config["qemu-args"].append(flag)
 
 
+@given('the config file "{config_file}"')
+def step_impl(context, config_file):
+    config_file_path = os.path.join("config-files/", config_file)
+    context.vm_config["transient-args"].extend(["-config", config_file_path])
+
+
 @when("the vm runs to completion")
 @when("the transient command is run")
 def step_impl(context):

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -125,7 +125,7 @@ def cli_entry(verbose: int) -> None:
     help="Copy a file or directory out of the VM after running "
     + "(/absolute/path/on/VM:path/on/host)",
 )
-@click.option("-name", help="Delete images associated with the given vm name")
+@click.option("-name", help="Create a vm with the given name")
 @click.option(
     "-ssh-console",
     "-ssh",

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -1,9 +1,9 @@
-import argparse
 import click
 import logging
 import signal
 import sys
 
+from . import configuration
 from . import image
 from . import transient
 from . import utils
@@ -22,13 +22,13 @@ def _get_version(
 
 
 _common_options = [
-    click.option("-image-frontend", help="The location to place per-vm disk images"),
+    click.option("-image-frontend", help="The location to place per-vm disk images",),
     click.option(
         "-image-backend",
         help="The location to place the shared, read-only backing disk images",
     ),
     click.option(
-        "-image", multiple=True, help="Disk image to use (this option can be repeated)"
+        "-image", multiple=True, help="Disk image to use (this option can be repeated)",
     ),
 ]
 
@@ -138,32 +138,31 @@ def cli_entry(verbose: int) -> None:
     is_flag=True,
     help="Show the serial output before SSH connects (implies -ssh)",
 )
-@click.option("-ssh-user", "-u", help="User to pass to SSH", default="vagrant")
-@click.option("-ssh-bin-name", help="SSH binary to use", default="ssh")
+@click.option("-ssh-user", "-u", help="User to pass to SSH")
+@click.option("-ssh-bin-name", help="SSH binary to use")
 @click.option(
-    "-ssh-timeout", default=90, help="Time to wait for SSH connection before failing"
+    "-ssh-timeout", help="Time to wait for SSH connection before failing",
 )
-@click.option("-ssh-port", help="Host port the guest port 22 is connected to")
-@click.option("-ssh-command", "-cmd", help="Run an ssh command instead of a console")
 @click.option(
-    "-shutdown-timeout",
-    default=20,
-    help="The time to wait for shutdown before terminating QEMU",
+    "-ssh-port", help="Host port the guest port 22 is connected to",
+)
+@click.option(
+    "-ssh-command", "-cmd", help="Run an ssh command instead of a console",
+)
+@click.option(
+    "-shutdown-timeout", help="The time to wait for shutdown before terminating QEMU",
 )
 @click.option(
     "-qmp-timeout",
-    default=10,
     help="The time in seconds to wait for the QEMU QMP connection to be established",
 )
 @click.option(
     "-copy-timeout",
-    default=None,
     help="The maximum time to wait for a copy-in-before or copy-out-after operation to complete",
 )
 @click.option(
     "-shared-folder",
     "-s",
-    default=[],
     multiple=True,
     help="Share a host directory with the guest (/path/on/host:/path/on/guest)",
 )
@@ -172,6 +171,7 @@ def cli_entry(verbose: int) -> None:
     is_flag=True,
     help="Only download/create vm disks. Do not start the vm",
 )
+@click.option("-config", "-c", nargs=1, help="Use a configuration file")
 @click.argument("QEMU_ARGS", nargs=-1)
 @cli_entry.command(name="run", cls=TransientRunCommand)
 def run_impl(**kwargs: Any) -> None:
@@ -179,11 +179,19 @@ def run_impl(**kwargs: Any) -> None:
 
     QEMU_ARGS will be passed directly to QEMU.
     """
-    args = argparse.Namespace(**kwargs)
+    try:
+        config = configuration.create_transient_run_config(kwargs)
+    except (
+        configuration.ConfigFileOptionError,
+        configuration.ConfigFileParsingError,
+        configuration.CLIArgumentError,
+    ):
+        sys.exit(1)
+
     store = image.ImageStore(
-        backend_dir=args.image_backend, frontend_dir=args.image_frontend
+        backend_dir=config.image_backend, frontend_dir=config.image_frontend
     )
-    trans = transient.TransientVm(config=args, store=store)
+    trans = transient.TransientVm(config=config, store=store)
 
     try:
         trans.run()
@@ -195,15 +203,21 @@ def run_impl(**kwargs: Any) -> None:
 @click.help_option("-h", "--help")
 @with_common_options
 @click.option("-force", "-f", help="Do not prompt before deletion", is_flag=True)
-@click.option("-name", help="Delete images associated with the given vm name")
+@click.option(
+    "-name", help="Delete images associated with the given vm name",
+)
 @cli_entry.command("delete")
 def delete_impl(**kwargs: Any) -> None:
     """Delete transient disks"""
-    args = argparse.Namespace(**kwargs)
+    try:
+        config = configuration.create_transient_delete_config(kwargs)
+    except configuration.CLIArgumentError:
+        sys.exit(1)
+
     store = image.ImageStore(
-        backend_dir=args.image_backend, frontend_dir=args.image_frontend
+        backend_dir=config.image_backend, frontend_dir=config.image_frontend
     )
-    images = _find_requested_images(store, args)
+    images = _find_requested_images(store, config)
 
     if len(images) == 0:
         print("No images match selection", file=sys.stderr)
@@ -218,7 +232,7 @@ def delete_impl(**kwargs: Any) -> None:
         print("\nBackend Images:")
         print(backend)
 
-    if args.force is False:
+    if config.force is False:
         response = utils.prompt_yes_no("Proceed?", default=False)
     else:
         response = True
@@ -234,15 +248,21 @@ def delete_impl(**kwargs: Any) -> None:
 
 @click.help_option("-h", "--help")
 @with_common_options
-@click.option("-name", help="List disks associated with the given vm name")
+@click.option(
+    "-name", help="List disks associated with the given vm name",
+)
 @cli_entry.command("list")
 def list_impl(**kwargs: Any) -> None:
     """List transient disk information"""
-    args = argparse.Namespace(**kwargs)
+    try:
+        config = configuration.create_transient_list_config(kwargs)
+    except configuration.CLIArgumentError:
+        sys.exit(1)
+
     store = image.ImageStore(
-        backend_dir=args.image_backend, frontend_dir=args.image_frontend
+        backend_dir=config.image_backend, frontend_dir=config.image_frontend
     )
-    images = _find_requested_images(store, args)
+    images = _find_requested_images(store, config)
 
     if len(images) == 0:
         print("No images match selection", file=sys.stderr)
@@ -259,21 +279,21 @@ def list_impl(**kwargs: Any) -> None:
 
 
 def _find_requested_images(
-    store: image.ImageStore, args: argparse.Namespace
+    store: image.ImageStore, config: configuration.Config
 ) -> List[image.BaseImageInfo]:
     images: List[image.BaseImageInfo] = []
-    if args.name is not None:
-        if len(args.image) == 0:
-            images = list(store.frontend_image_list(args.name))
+    if config.name is not None:
+        if len(config.image) == 0:
+            images = list(store.frontend_image_list(config.name))
         else:
-            for image_identifier in args.image:
-                images.extend(store.frontend_image_list(args.name, image_identifier))
+            for image_identifier in config.image:
+                images.extend(store.frontend_image_list(config.name, image_identifier))
     else:
-        if len(args.image) == 0:
+        if len(config.image) == 0:
             images = list(store.backend_image_list())
             images.extend(store.frontend_image_list())
         else:
-            for image_identifier in args.image:
+            for image_identifier in config.image:
                 images.extend(store.backend_image_list(image_identifier))
                 images.extend(
                     store.frontend_image_list(image_identifier=image_identifier)

--- a/transient/configuration.py
+++ b/transient/configuration.py
@@ -1,0 +1,293 @@
+"""Supports the creation and validation of Transient-run configurations
+"""
+
+import logging
+import toml
+
+from marshmallow import Schema, fields, post_load, pre_load, ValidationError
+
+from typing import Any, Dict, List, MutableMapping
+
+
+class ConfigFileParsingError(Exception):
+    """Raised when a parsing error is encountered while loading the
+       configuration file
+    """
+
+    pass
+
+
+class ConfigFileOptionError(Exception):
+    """Raised when an invalid configuration option value is encountered in the
+       configuration file
+    """
+
+    pass
+
+
+class CLIArgumentError(Exception):
+    """Raised when an invalid command line argument is encountered
+    """
+
+    pass
+
+
+class Config(Dict[Any, Any]):
+    """Creates an argument dictionary that allows dot notation to access values
+
+    Example:
+
+        >>> args = Config({'arg1': 1, 'arg2': 2})
+        >>> args['arg1'] == args.arg1
+
+    """
+
+    def __getattr__(self, attr: Any) -> Any:
+        return self.get(attr)
+
+    def __setattr__(self, key: Any, value: Any) -> None:
+        self.__setitem__(key, value)
+
+    def __delattr__(self, item: Any) -> None:
+        self.__delitem__(item)
+
+
+class _TransientConfigSchema(Schema):
+    """Defines a common schema for the Transient configurations and validates
+       the fields during deserialization
+    """
+
+    image = fields.List(fields.Str(), missing=[])
+    image_backend = fields.Str(allow_none=True)
+    image_frontend = fields.Str(allow_none=True)
+    name = fields.Str(allow_none=True)
+
+    # marshmallow's decorator pre_load() is untyped, forcing
+    # remove_unset_options() to be untyped. Therefore, we ignore it to
+    # silence the type checker
+    @pre_load  # type: ignore
+    def remove_unset_options(
+        self, config: Dict[Any, Any], **kwargs: Dict[Any, Any]
+    ) -> Dict[Any, Any]:
+        """Removes any option that was not set in the command line
+        """
+        config_without_unset_options = {}
+        for option, value in config.items():
+            if _option_was_set_in_cli(config[option]):
+                config_without_unset_options[option] = value
+
+        return config_without_unset_options
+
+    # marshmallow's decorator post_load() is untyped, forcing create_args()
+    # to be untyped. Therefore, we ignore it to silence the type checker
+    @post_load  # type: ignore
+    def create_config(self, data: Dict[Any, Any], **kwargs: Dict[Any, Any]) -> Config:
+        """Returns the Config dictionary after a schema is loaded and validated
+        """
+        return Config(**data)
+
+
+class _TransientDeleteConfigSchema(_TransientConfigSchema):
+    """Defines the schema for the Transient-delete configuration and validates
+       the fields during deserialization
+    """
+
+    force = fields.Bool(missing=False)
+
+
+class _TransientListConfigSchema(_TransientConfigSchema):
+    """Defines the schema for the Transient-list configuration and validates
+       the fields during deserialization
+
+       Note that this class is a wrapper to maintain symmetry with the other
+       schemas.
+    """
+
+    pass
+
+
+class _TransientRunConfigSchema(_TransientConfigSchema):
+    """Defines the schema for the Transient-run configuration and validates the
+       fields during deserialization
+    """
+
+    config = fields.Str(allow_none=True)
+    copy_in_before = fields.List(fields.Str(), missing=[])
+    copy_out_after = fields.List(fields.Str(), missing=[])
+    copy_timeout = fields.Int(allow_none=True)
+    prepare_only = fields.Bool(missing=False)
+    qemu_args = fields.List(fields.Str(), allow_none=True)
+    qmp_timeout = fields.Int(missing=10, allow_none=True)
+    shutdown_timeout = fields.Int(missing=20)
+    ssh_command = fields.Str(allow_none=True)
+    ssh_bin_name = fields.Str(missing="ssh", allow_none=True)
+    ssh_port = fields.Int(allow_none=True)
+    ssh_timeout = fields.Int(missing=90, allow_none=True)
+    ssh_user = fields.Str(missing="vagrant", allow_none=True)
+    ssh_console = fields.Bool(missing=False)
+    ssh_with_serial = fields.Bool(missing=False)
+    shared_folder = fields.List(fields.Str(), missing=[])
+
+
+def _option_was_set_in_cli(option: Any) -> bool:
+    """Returns True if an option was set in the command line
+    """
+    if option is None or option == () or option is False:
+        return False
+
+    return True
+
+
+def _get_line_number_of_option_in_config_file(option: str, config_file_path: str) -> int:
+    """Returns the line number where the option is found in the config file
+    """
+    with open(config_file_path) as config_file:
+        for line_number, line in enumerate(config_file, start=1):
+            if option in line:
+                return line_number
+
+    return -1
+
+
+def _log_error_message_for_invalid_config_file_option(
+    error: ValidationError, config_file_path: str
+) -> None:
+    """Logs an error message regarding an invalid configuration in the config file
+       and its associated line number
+    """
+    for invalid_option in error.messages:
+
+        # Revert the option to its preformatted state
+        invalid_option = invalid_option.replace("_", "-")
+
+        line_number = _get_line_number_of_option_in_config_file(
+            invalid_option, config_file_path
+        )
+
+        if line_number != -1:
+            logging.error(
+                f"Invalid option on line {line_number} in configuration file: {invalid_option}",
+            )
+        else:
+            logging.error(f"Invalid option in configuration file: {error}")
+
+
+def _replace_hyphens_with_underscores_in_dict_keys(
+    dictionary: Dict[Any, Any]
+) -> Dict[Any, Any]:
+    """Replaces hyphens in the dictionary keys with underscores
+
+       This is the expected key format for _TransientConfigSchema
+    """
+    final_dict = {}
+    for k, v in dictionary.items():
+        # Perform this method recursively for sub-directories
+        if isinstance(dictionary[k], dict):
+            new_v = _replace_hyphens_with_underscores_in_dict_keys(v)
+            final_dict[k.replace("-", "_")] = new_v
+        else:
+            final_dict[k.replace("-", "_")] = v
+
+    return final_dict
+
+
+def _parse_config_file(config_file_path: str) -> MutableMapping[str, Any]:
+    """Parses the given config file and returns the contents as a dictionary
+    """
+    with open(config_file_path) as file:
+        config_file = file.read()
+
+    try:
+        parsed_config_file = toml.loads(config_file)
+    except RuntimeError as error:
+        logging.error(f"Failed to parse configuration file: {error}")
+        raise ConfigFileParsingError(error)
+
+    return parsed_config_file
+
+
+def _load_config_file(config_file_path: str) -> Config:
+    """Reformats and validates the config file
+    """
+    parsed_config_file = _parse_config_file(config_file_path)
+
+    reformatted_config = _replace_hyphens_with_underscores_in_dict_keys(
+        parsed_config_file["transient"]
+    )
+
+    reformatted_config["qemu_args"] = parsed_config_file["qemu"]["qemu-args"]
+
+    transient_config_schema = _TransientRunConfigSchema()
+
+    try:
+        config: Config = transient_config_schema.load(reformatted_config)
+    except ValidationError as error:
+        _log_error_message_for_invalid_config_file_option(error, config_file_path)
+        raise ConfigFileOptionError(error)
+
+    return config
+
+
+def _consolidate_cli_args_and_config_file(cli_args: Dict[Any, Any]) -> Dict[Any, Any]:
+    """Consolidates and returns the CLI arguments and the configuration file
+
+       Note that the CLI arguments take precedence over the configuration file
+    """
+    config = _load_config_file(cli_args["config"])
+
+    for option, value in config.items():
+        if (
+            option == "qemu_args" and cli_args[option] == ()
+        ) or not _option_was_set_in_cli(cli_args[option]):
+            cli_args[option] = value
+
+    return cli_args
+
+
+def _create_transient_config_with_schema(
+    config: Dict[Any, Any], schema: _TransientConfigSchema
+) -> Config:
+    """Creates and validates the Config to be used by Transient given the
+       CLI arguments and schema
+    """
+    try:
+        validated_config: Config = schema.load(config)
+    except ValidationError as error:
+        logging.error(f"Invalid command line arguments given: {error}")
+        raise CLIArgumentError(error)
+
+    return validated_config
+
+
+def create_transient_list_config(cli_args: Dict[Any, Any]) -> Config:
+    """Creates and validates the Config to be used by Transient-list given the
+       CLI arguments
+    """
+    schema = _TransientListConfigSchema()
+
+    return _create_transient_config_with_schema(cli_args, schema)
+
+
+def create_transient_delete_config(cli_args: Dict[Any, Any]) -> Config:
+    """Creates and validates the Config to be used by Transient-delete given
+       the CLI arguments
+    """
+    schema = _TransientDeleteConfigSchema()
+
+    return _create_transient_config_with_schema(cli_args, schema)
+
+
+def create_transient_run_config(cli_args: Dict[Any, Any]) -> Config:
+    """Creates and validates the Config to be used by Transient-run
+       given the CLI arguments and, if specified, a config file
+
+       Note that the CLI arguments take precedence over the config file
+    """
+    if cli_args["config"]:
+        config = _consolidate_cli_args_and_config_file(cli_args)
+    else:
+        config = cli_args
+
+    schema = _TransientRunConfigSchema()
+
+    return _create_transient_config_with_schema(config, schema)

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -1,3 +1,4 @@
+from . import configuration
 from . import qemu
 from . import image
 from . import utils
@@ -5,7 +6,6 @@ from . import ssh
 from . import sshfs
 from . import static
 
-import argparse
 import enum
 import glob
 import logging
@@ -15,7 +15,7 @@ import signal
 import subprocess
 import uuid
 
-from typing import cast, Optional, List, Dict, Any, Union, Tuple, TYPE_CHECKING
+from typing import cast, Optional, List, Any, Union, Tuple, TYPE_CHECKING
 
 # _Environ is declared as generic in stubs but not at runtime. This makes it
 # non-subscriptable and will result in a runtime error. According to the
@@ -42,13 +42,13 @@ class TransientVmState(enum.Enum):
 
 class TransientVm:
     store: image.ImageStore
-    config: argparse.Namespace
+    config: configuration.Config
     vm_images: List[image.FrontendImageInfo]
     ssh_config: Optional[ssh.SshConfig]
     qemu_runner: Optional[qemu.QemuRunner]
     qemu_should_die: bool
 
-    def __init__(self, config: argparse.Namespace, store: image.ImageStore) -> None:
+    def __init__(self, config: configuration.Config, store: image.ImageStore) -> None:
         self.store = store
         self.config = config
         self.vm_images = []
@@ -362,7 +362,7 @@ class TransientVm:
         print("Finished preparation. Starting virtual machine")
 
         added_qemu_args = self.__qemu_added_args()
-        full_qemu_args = added_qemu_args + list(self.config.qemu_args)
+        full_qemu_args = added_qemu_args + self.config.qemu_args
 
         # If we are using the SSH console, we need to do _something_ with QEMU output.
         qemu_quiet, qemu_interactive = False, True


### PR DESCRIPTION
I added config file support using toml and marshmallow.

A default config file can be created using `transient init` and `transient init -name config-file-name`.

The default config explains the format. QEMU args remain an arbitrary list of strings.

I added some very basic behave tests, but I still want to add actual unit tests.

I look forward to your feedback and ways we can improve this pull request. Thanks Adam!