### PR TITLE
Multithreaded the shared-directory setup process

### DIFF
--- a/test/features/sshfs.feature
+++ b/test/features/sshfs.feature
@@ -12,3 +12,15 @@ Feature: SSH Console
      When the vm runs to completion
      Then the return code is 0
       And stdout contains "TEST_FOLDER_INDICATOR"
+
+  @skip-in-ci
+  Scenario: Run VM with two SSHFS mounts
+    Given a transient vm
+      And a disk image "centos/7:2004.01"
+      And a sshfs mount of "resources/sync:/mnt"
+      And a sshfs mount of "resources:/mnt2"
+      And a ssh command "ls /mnt /mnt2"
+     When the vm runs to completion
+     Then the return code is 0
+      And stdout contains "TEST_FOLDER_INDICATOR"
+      And stdout contains "sync"

--- a/transient/checked_threading.py
+++ b/transient/checked_threading.py
@@ -1,0 +1,22 @@
+import threading
+
+from typing import Optional
+
+# This class only exists because "threading.Thread" does not offer any
+# programmatic indication of whether the thread hit an exception.
+class Thread(threading.Thread):
+
+    exception: Optional[Exception] = None
+
+    def run(self) -> None:
+        try:
+            super().run()
+        except Exception as e:
+            self.exception = e
+            raise
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        super().join(timeout=timeout)
+
+        if self.exception:
+            raise self.exception


### PR DESCRIPTION
Resolves #19 

Added multithreading to the SSHFS mounts. These changes, on my machine, accelerate the process of booting and immediately shutting down a CentOS VM with 20 shared folders from a minute to only 23 seconds. This would be even faster except that I limited it to only run 8 threads at a time. When I tried launching with 20 simultaneous threads, my host machine's SSH server frequently started refusing connections.

Python's Thread class does not give any built-in method to find whether it actually succeeded. To error out properly if, for instance, the host does not have a running SSH server, I wrote a small wrapper class for `threading.Thread`. Its only added functionality is to raise any caught error when `join()` is called.

`make test` passes.