### PR TITLE
Read-only Backend

### DIFF
--- a/transient/build.py
+++ b/transient/build.py
@@ -6,6 +6,7 @@ import json
 import pathlib
 import re
 import shutil
+import stat
 import subprocess
 
 from . import configuration
@@ -654,6 +655,9 @@ class ImageBuilder:
             destination = os.path.join(self.config.build_dir, f"{self.config.name}.qcow2")
         else:
             destination = self.store.backend_path(image.ImageSpec(self.config.name))
+
+        # Make the new image read-only before moving.
+        os.chmod(new_image, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
         os.rename(new_image, destination)
 
         return destination

--- a/transient/image.py
+++ b/transient/image.py
@@ -4,6 +4,7 @@ import logging
 import fcntl
 import itertools
 import os
+import stat
 import progressbar  # type: ignore
 import re
 import requests
@@ -64,6 +65,10 @@ class BaseImageProtocol:
             # Now that the entire file is retrieved, atomically move it to the destination.
             # This avoids issues where a process was killed in the middle of retrieval
             os.rename(temp_destination, destination)
+
+            # There is a qemu hotkey to commit a 'snapshot' to the backing file.
+            # Making the backend images read-only prevents this.
+            os.chmod(destination, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
 
     def _do_retrieve_image(
         self, store: "ImageStore", spec: "ImageSpec", destination: IO[bytes]


### PR DESCRIPTION
Goal: Sets the backend image's file permissions to read-only in order to prevent unintentional modifications from qemu hotkeys.

Closes #77 