### PR TITLE
config: add option for net device type config

### DIFF
--- a/transient/cli.py
+++ b/transient/cli.py
@@ -159,6 +159,11 @@ def cli_entry(verbose: int) -> None:
     "-ssh-command", "-cmd", type=str, help="Run an ssh command instead of a console",
 )
 @click.option(
+    "-ssh-net-driver",
+    type=str,
+    help="The QEMU virtual network device driver e.g. e1000, rtl8139, virtio-net-pci (default)",
+)
+@click.option(
     "-shutdown-timeout",
     type=int,
     help="The time to wait for shutdown before terminating QEMU",

--- a/transient/configuration.py
+++ b/transient/configuration.py
@@ -181,6 +181,7 @@ class _TransientRunConfigSchema(_TransientConfigSchema):
     qemu_args = fields.List(fields.Str(), missing=[])
     qmp_timeout = fields.Int(missing=10, allow_none=True)
     shutdown_timeout = fields.Int(missing=20)
+    ssh_net_driver = fields.Str(missing="virtio-net-pci")
     ssh_command = fields.Str(allow_none=True)
     ssh_bin_name = fields.Str(missing="ssh", allow_none=True)
     ssh_port = fields.Int(allow_none=True)

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -228,13 +228,15 @@ class TransientVm:
                 ssh_bin_name=self.config.ssh_bin_name,
             )
 
+            ssh_net_driver = self.config.ssh_net_driver
+
             # the random localhost port or the user provided port to guest port 22
             new_args.extend(
                 [
                     "-netdev",
                     f"user,id=transient-sshdev,hostfwd=tcp::{ssh_port}-:22",
                     "-device",
-                    "e1000,netdev=transient-sshdev",
+                    f"{ssh_net_driver},netdev=transient-sshdev",
                 ]
             )
 


### PR DESCRIPTION
Allow the user to configure the net device type. The default should be
virtio-net-pci, but the user should be able to specify alternate drivers
if they would like to use e1000 or rtl8139.