### PR TITLE
Add CLI option 'qemu-bin-name' to specify which QEMU binary to use

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -90,6 +90,9 @@ before booting the VM. For example `-copy-in-before path/on/host:/path/on/guest`
 - `-copy-out-after`: Copy the contents of a guest directory to a location on the hose
 after shutting down the VM. For example `-copy-out-after path/on/host:/path/on/guest`
 
+- `-qemu-bin-name NAME`: Use `NAME` instead of `qemu-system-x86_64` as the QEMU
+binary.
+
 #### Examples
 
 ##### Run a CentOS 7 VM with Serial Console

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -169,6 +169,9 @@ def cli_entry(verbose: int) -> None:
     help="The time to wait for shutdown before terminating QEMU",
 )
 @click.option(
+    "-qemu-bin-name", type=str, default="qemu-system-x86_64", help="QEMU binary to use"
+)
+@click.option(
     "-qmp-timeout",
     type=int,
     help="The time in seconds to wait for the QEMU QMP connection to be established",

--- a/transient/configuration.py
+++ b/transient/configuration.py
@@ -178,6 +178,7 @@ class _TransientRunConfigSchema(_TransientConfigSchema):
     copy_out_after = fields.List(fields.Str(), missing=[])
     copy_timeout = fields.Int(allow_none=True)
     prepare_only = fields.Bool(missing=False)
+    qemu_bin_name = fields.Str(allow_none=True)
     qemu_args = fields.List(fields.Str(), missing=[])
     qmp_timeout = fields.Int(missing=10, allow_none=True)
     shutdown_timeout = fields.Int(missing=20)

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -353,6 +353,7 @@ class TransientVm:
         # `-nographic` mode, which is very surprising.
         self.qemu_runner = qemu.QemuRunner(
             full_qemu_args,
+            bin_name=self.config.qemu_bin_name,
             quiet=qemu_quiet,
             interactive=qemu_interactive,
             qmp_connectable=self.__needs_ssh_console(),


### PR DESCRIPTION
A note for the PR: I was running this on Ubuntu 20.04 and I had errors both from the formatter, mypy, and the tests would not run. I see there is test-ubuntu-20.04 branch out there so I just isolated the change in question on this pull.

Otherwise, the formatting and mypy changes are sitting at https://github.com/sruffell/transient/commits/sruffell-wip if you need me to incorporate them here and reissue this PR.

The failure I was first seeing when running the test is:
```
  Scenario: The built image is usable              # features/build.feature:34
    Given a transient vm                           # features/steps/steps.py:49
    Given a transient vm                           # features/steps/steps.py:49 0.000s
    And a disk image "test-build-ubuntu-backend"   # features/steps/steps.py:107
    And a disk image "test-build-ubuntu-backend"   # features/steps/steps.py:107 0.000s
    And a backend "./artifacts/test-backend"       # features/steps/steps.py:139
    And a backend "./artifacts/test-backend"       # features/steps/steps.py:139 0.000s
    And a ssh command "echo 'ssh-command working'" # features/steps/steps.py:122
    And a ssh command "echo 'ssh-command working'" # features/steps/steps.py:122 0.000s
    When the vm runs to completion                 # features/steps/steps.py:215
    When the vm runs to completion                 # features/steps/steps.py:215 0.268s
    Then the return code is 0                      # features/steps/steps.py:239
    Then the return code is 0                      # features/steps/steps.py:239 0.000s
      Assertion Failed:
      Expected: <0>
           but: was <1>

      Captured stdout:
      ['transient', 'run', '-image', 'test-build-ubuntu-backend', '-image-backend', './artifacts/test-backend', '-ssh-command', "echo 'ssh-command working'", '--', '-m', '1G', '-smp', '2', '-enable-kvm', '-cpu',
      command stdout:
      > /home/sruffell/.local/lib/python3.8/site-packages/transient-0.10-py3.8.egg/transient/cli.py(214)run_impl()
      -> try:
      (Pdb)

      command stderr:
      Traceback (most recent call last):
        File "/home/sruffell/.local/bin/transient", line 11, in <module>
          load_entry_point('transient==0.10', 'console_scripts', 'transient')()
        File "/home/sruffell/.local/lib/python3.8/site-packages/transient-0.10-py3.8.egg/transient/cli.py", line 393, in main
        File "/home/sruffell/.local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
          return self.main(*args, **kwargs)
        File "/home/sruffell/.local/lib/python3.8/site-packages/click/core.py", line 782, in main
          rv = self.invoke(ctx)
        File "/home/sruffell/.local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
          return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "/home/sruffell/.local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
          return ctx.invoke(self.callback, **ctx.params)
        File "/home/sruffell/.local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
          return callback(*args, **kwargs)
        File "/home/sruffell/.local/lib/python3.8/site-packages/transient-0.10-py3.8.egg/transient/cli.py", line 214, in run_impl
        File "/home/sruffell/.local/lib/python3.8/site-packages/transient-0.10-py3.8.egg/transient/cli.py", line 214, in run_impl
        File "/usr/lib/python3.8/bdb.py", line 88, in trace_dispatch
          return self.dispatch_line(frame)
        File "/usr/lib/python3.8/bdb.py", line 113, in dispatch_line
          if self.quitting: raise BdbQuit
      bdb.BdbQuit

    And stdout contains "ssh-command working"      # None
```

But it looks like `make test` is using the installed transient and not the local module?


Closes #4