### PR TITLE
Avoid copy in copy out to all images

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -85,10 +85,12 @@ Shared Folders](/details/shared-folders/).
 steps outlined above. It will not start the guest virtual machine.
 
 - `-copy-in-before`: Copy the contents of a host directory to a location on the guest
-before booting the VM. For example `-copy-in-before path/on/host:/path/on/guest`
+before booting the VM. This will only copy to the first `-image` specified.
+For example `-copy-in-before path/on/host:/path/on/guest`
 
 - `-copy-out-after`: Copy the contents of a guest directory to a location on the hose
-after shutting down the VM. For example `-copy-out-after path/on/host:/path/on/guest`
+after shutting down the VM. This will only copy from the first `-image` specified.
+For example `-copy-out-after path/on/host:/path/on/guest`
 
 - `-qemu-bin-name NAME`: Use `NAME` instead of `qemu-system-x86_64` as the QEMU
 binary.

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -161,15 +161,16 @@ class TransientVm:
         if not vm_absolute_path.startswith("/"):
             raise RuntimeError(f"Absolute path for guest required: {vm_absolute_path}")
 
-        for vm_image in self.vm_images:
-            assert isinstance(vm_image, image.FrontendImageInfo)
-            assert vm_image.backend is not None
-            logging.info(
-                f"Copying from '{host_path}' to '{vm_image.backend.identifier}:{vm_absolute_path}'"
-            )
+        # For now copy only to the first "-image" specified.
+        vm_image = self.vm_images[0]
+        assert isinstance(vm_image, image.FrontendImageInfo)
+        assert vm_image.backend is not None
+        logging.info(
+            f"Copying from '{host_path}' to '{vm_image.backend.identifier}:{vm_absolute_path}'"
+        )
 
-            with editor.ImageEditor(self.config, vm_image.path) as edit:
-                edit.copy_in(host_path, vm_absolute_path)
+        with editor.ImageEditor(self.config, vm_image.path) as edit:
+            edit.copy_in(host_path, vm_absolute_path)
 
     def __needs_to_copy_out_files_after_running(self) -> bool:
         """Checks if at least one directory on the VM needs to be copied out
@@ -199,15 +200,16 @@ class TransientVm:
         if not vm_absolute_path.startswith("/"):
             raise RuntimeError(f"Absolute path for guest required: {vm_absolute_path}")
 
-        for vm_image in self.vm_images:
-            assert isinstance(vm_image, image.FrontendImageInfo)
-            assert vm_image.backend is not None
-            logging.info(
-                f"Copying from '{vm_image.backend.identifier}:{vm_absolute_path}' to '{host_path}'"
-            )
+        # For now copy only to the first "-image" specified.
+        vm_image = self.vm_images[0]
+        assert isinstance(vm_image, image.FrontendImageInfo)
+        assert vm_image.backend is not None
+        logging.info(
+            f"Copying from '{vm_image.backend.identifier}:{vm_absolute_path}' to '{host_path}'"
+        )
 
-            with editor.ImageEditor(self.config, vm_image.path) as edit:
-                edit.copy_out(vm_absolute_path, host_path)
+        with editor.ImageEditor(self.config, vm_image.path) as edit:
+            edit.copy_out(vm_absolute_path, host_path)
 
     def __qemu_added_args(self) -> List[str]:
         new_args = ["-name", self.name]


### PR DESCRIPTION
Closes #122 

Only copy to the first `-image` specified. This applies to both `copy-in-before` and `copy-out-after`.