### PR TITLE
Pass options directly to SSH using -o/-ssh-option

### DIFF
--- a/test/features/ssh_command.feature
+++ b/test/features/ssh_command.feature
@@ -20,3 +20,20 @@ Feature: SSH Command
      When a transient ssh command "echo ssh-command working" runs on "test-vm" with timeout 30
      Then the return code is 1
       And stderr contains "No running VMs"
+
+  Scenario: We can run ssh with custom options
+    Given a transient vm
+      And a disk image "generic/alpine38:v3.0.2"
+      And a ssh command "sleep 600"
+      And a ssh console
+      And a name "test-vm"
+      And extra argument "-ssh-option ControlMaster=yes"
+      And extra argument "-ssh-option ControlPath=myctrlsock"
+     When the vm runs
+     Then the file "myctrlsock" appears
+      And the following shell commands should succeed
+         """
+         scp -o ControlPath=myctrlsock foo:/etc/os-release os-release
+         grep 'ID=alpine' os-release
+         """
+      And the vm is terminated

--- a/test/features/ssh_command.feature
+++ b/test/features/ssh_command.feature
@@ -21,7 +21,7 @@ Feature: SSH Command
      Then the return code is 1
       And stderr contains "No running VMs"
 
-  Scenario: We can run ssh with custom options
+  Scenario: Run ssh with custom options
     Given a transient vm
       And a disk image "generic/alpine38:v3.0.2"
       And a ssh command "sleep 600"
@@ -30,10 +30,6 @@ Feature: SSH Command
       And extra argument "-ssh-option ControlMaster=yes"
       And extra argument "-ssh-option ControlPath=myctrlsock"
      When the vm runs
-     Then the file "myctrlsock" appears
-      And the following shell commands should succeed
-         """
-         scp -o ControlPath=myctrlsock foo:/etc/os-release os-release
-         grep 'ID=alpine' os-release
-         """
+     Then the file "myctrlsock" appears within 180 seconds
+      And "myctrlsock" is a socket
       And the vm is terminated

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -342,6 +342,7 @@ def step_impl(context, file_path, seconds):
         time.sleep(1)
     assert False, f"File {file_path} didn't appear"
 
+
 @then('"{file_path}" is a socket')
 def step_impl(context, file_path):
     info = os.stat(file_path)

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -338,7 +338,7 @@ def step_impl(context, file_path):
         time.sleep(1)
     assert False, f"File {file_path} didn't appear"
 
-@then('the following commands should succeed')
+@then('the following shell commands should succeed')
 def step_impl(context):
     script = 'set -ex\n' + context.text
     result = subprocess.run(

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -127,10 +127,12 @@ def step_impl(context, image):
 def step_impl(context):
     context.vm_config["transient-args"].extend(["-ssh-console"])
 
+
 @given('extra argument "{arg}"')
 def step_impl(context, arg):
     args = shlex.split(arg)
     context.vm_config["transient-args"].extend(args)
+
 
 @given("a ssh-with-serial console")
 def step_impl(context):
@@ -330,6 +332,7 @@ def step_impl(context, name):
 def step_impl(context, file_path):
     assert os.path.exists(file_path)
 
+
 @then('the file "{file_path}" appears')
 def step_impl(context, file_path):
     for _ in range(60):
@@ -338,14 +341,16 @@ def step_impl(context, file_path):
         time.sleep(1)
     assert False, f"File {file_path} didn't appear"
 
-@then('the following shell commands should succeed')
+
+@then("the following shell commands should succeed")
 def step_impl(context):
-    script = 'set -ex\n' + context.text
+    script = "set -ex\n" + context.text
     result = subprocess.run(
-            ['/bin/bash'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            input=script,
-            universal_newlines=True)
-    print(result.stdout) # so behave can capture it and display it on error
+        ["/bin/bash"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        input=script,
+        universal_newlines=True,
+    )
+    print(result.stdout)  # so behave can capture it and display it on error
     result.check_returncode()

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -6,6 +6,7 @@ import time
 import shlex
 from behave import *
 from hamcrest import *
+import stat
 
 # Wait for a while, as we may be downloading the image as well
 VM_WAIT_TIME = 60 * 15
@@ -333,24 +334,15 @@ def step_impl(context, file_path):
     assert os.path.exists(file_path)
 
 
-@then('the file "{file_path}" appears')
-def step_impl(context, file_path):
-    for _ in range(300):
+@then('the file "{file_path}" appears within {seconds} seconds')
+def step_impl(context, file_path, seconds):
+    for _ in range(int(seconds)):
         if os.path.exists(file_path):
             return
         time.sleep(1)
     assert False, f"File {file_path} didn't appear"
 
-
-@then("the following shell commands should succeed")
-def step_impl(context):
-    script = "set -ex\n" + context.text
-    result = subprocess.run(
-        ["/bin/bash"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        input=script,
-        universal_newlines=True,
-    )
-    print(result.stdout)  # so behave can capture it and display it on error
-    result.check_returncode()
+@then('"{file_path}" is a socket')
+def step_impl(context, file_path):
+    info = os.stat(file_path)
+    assert stat.S_ISSOCK(info.st_mode), f"File {file_path} is not a socket"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -335,7 +335,7 @@ def step_impl(context, file_path):
 
 @then('the file "{file_path}" appears')
 def step_impl(context, file_path):
-    for _ in range(60):
+    for _ in range(300):
         if os.path.exists(file_path):
             return
         time.sleep(1)

--- a/transient/cli.py
+++ b/transient/cli.py
@@ -50,6 +50,9 @@ _ssh_options = [
     click.option(
         "-ssh-command", "-cmd", type=str, help="Run an ssh command instead of a console",
     ),
+    click.option(
+        "-ssh-option", "-o", multiple=True, type=str, help="Pass an option to SSH",
+    ),
 ]
 
 
@@ -328,6 +331,7 @@ def ssh_impl(**kwargs: Any) -> None:
         user=config.ssh_user,
         ssh_bin_name=config.ssh_bin_name,
         port=instance.ssh_port,
+        extra_options=config.ssh_option,
     )
     client = ssh.SshClient(config=ssh_config, command=config.ssh_command)
     connection = client.connect_stdout(config.ssh_timeout)

--- a/transient/configuration.py
+++ b/transient/configuration.py
@@ -218,6 +218,7 @@ class _TransientRunConfigSchema(_TransientConfigSchema):
     ssh_user = fields.Str(missing="vagrant", allow_none=True)
     ssh_console = fields.Bool(missing=False)
     ssh_with_serial = fields.Bool(missing=False)
+    ssh_option = fields.List(fields.Str(), missing=[])
     shared_folder = fields.List(fields.Str(), missing=[])
     sftp_bin_name = fields.Str(missing="sftp-server", allow_none=True)
     no_virtio_scsi = fields.Bool(missing=False)

--- a/transient/ssh.py
+++ b/transient/ssh.py
@@ -35,6 +35,7 @@ class SshConfig:
         user: Optional[str] = None,
         password: Optional[str] = None,
         args: Optional[List[str]] = None,
+        extra_options: Optional[List[str]] = None,
     ) -> None:
         self.host = host
         self.port = port if port is not None else 22
@@ -46,6 +47,9 @@ class SshConfig:
 
         # Pass these as default args
         self.args.extend(self.__default_ssh_args())
+        if extra_options:
+            for opt in extra_options:
+                self.args.extend(['-o', opt])
 
     def __default_ssh_args(self) -> List[str]:
         return [

--- a/transient/ssh.py
+++ b/transient/ssh.py
@@ -49,7 +49,7 @@ class SshConfig:
         self.args.extend(self.__default_ssh_args())
         if extra_options:
             for opt in extra_options:
-                self.args.extend(['-o', opt])
+                self.args.extend(["-o", opt])
 
     def __default_ssh_args(self) -> List[str]:
         return [

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -263,6 +263,7 @@ class TransientVm:
             user=self.config.ssh_user,
             ssh_bin_name=self.config.ssh_bin_name,
             sftp_server_bin_name=self.config.sftp_server_bin_name,
+            extra_options=self.config.ssh_option,
         )
 
     def __connect_ssh(self) -> int:


### PR DESCRIPTION
Passing options to SSH enables a bunch of useful things:

- Port forwarding
- `scp` files from a running VM using ControlMaster
- Dynamically controlling port forwarding using ControlMaster
- Fine tuning timeout, keepalives, etc.
