### PR TITLE
Use existing QEMU session for copy-in/copy-out

### DIFF
--- a/docs/cli/run_create_start_stop.md
+++ b/docs/cli/run_create_start_stop.md
@@ -98,6 +98,7 @@ ones common to both subcommands are described below:
                                      (/absolute/path/on/VM:path/on/host)
 - `--copy-timeout COPY_TIMEOUT`: The maximum time to wait for a copy-in-before or
                                  copy-out-after operation to complete
+- `--direct-copy`:    Transfier files specified via `--copy-in-before` or `--copy-in-after` directly to the VM, instead of a background 'builder' VM
 - `--rsync`: Use rsync for copy-in-before/copy-out-after operations
 
 #### VM Creation Flags
@@ -150,7 +151,7 @@ described below:
 ### Create and Start an Alpine VM
 
 ```
-$ transient create --name bar --ssh alpine_rel3,http=https://github.com/ALSchwalm/transient-baseimages/releases/download/5/alpine-3.13.qcow2.xz
+$ transient create --name bar --ssh alpine_rel3,http=https://github.com/ALSchwalm/transient-baseimages/releases/download/6/alpine-3.13.qcow2.xz
 Unable to find image 'alpine' in backend
 Downloading image from 'https://github.com/ALSchwalm/transient-baseimages/releases/download/5/alpine-3.13.qcow2.xz'
 100% |##############################################|  12.7 MiB/s |  35.0 MiB | Time:  0:00:02

--- a/test/features/copy-in-copy-out.feature
+++ b/test/features/copy-in-copy-out.feature
@@ -5,58 +5,88 @@ Feature: Copy-in and Copy-out Support
   - copy the host file or directory to the guest directory before starting the VM
   - copy the guest file or directory to the host directory after stopping the VM
 
-  Scenario: Copy in a file before starting VM
+  Scenario Outline: Copy in a file before starting VM
     Given a transient run command
       And an http alpine disk image
       And a test file: "artifacts/copy-in-before-test-file"
       And a guest directory: "/home/vagrant/"
       And the test file is copied to the guest directory before starting
+      And using the "<image_type>" image for copying
       And a ssh command "ls /home/vagrant"
      When the vm runs to completion
      Then the return code is 0
       And stdout contains "copy-in-before-test-file"
 
-  Scenario: Copy in a large file before starting VM
+    Examples: Image Types
+      | image_type |
+      | dedicated  |
+      | same       |
+
+  Scenario Outline: Copy in a large file before starting VM
     Given a transient run command
       And an http alpine disk image
       And a large test file: "artifacts/copy-in-large-test-file"
       And a guest directory: "/home/vagrant/"
       And the test file is copied to the guest directory before starting
+      And using the "<image_type>" image for copying
       And a ssh command "ls /home/vagrant"
      When the vm runs to completion
      Then the return code is 0
       And stdout contains "copy-in-large-test-file"
 
-  Scenario: Copy out a file after stopping VM
+    Examples: Image Types
+      | image_type |
+      | dedicated  |
+      | same       |
+
+  Scenario Outline: Copy out a file after stopping VM
     Given a transient run command
       And an http alpine disk image
       And a host directory: "artifacts/"
       And a guest test file: "/home/vagrant/copy-out-after-test-file"
       And the guest test file is copied to the host directory after stopping
+      And using the "<image_type>" image for copying
       And a ssh command "touch /home/vagrant/copy-out-after-test-file"
      When the vm runs to completion
      Then the return code is 0
       And the file "artifacts/copy-out-after-test-file" exists
 
-  Scenario: Copy out a file after stopping VM using rsync
+    Examples: Image Types
+      | image_type |
+      | dedicated  |
+      | same       |
+
+  Scenario Outline: Copy out a file after stopping VM using rsync
     Given a transient run command
       And an http alpine disk image
       And a host directory: "artifacts/"
       And a guest test file: "/home/vagrant/copy-out-after-test-file"
       And the guest test file is copied to the host directory after stopping
+      And using the "<image_type>" image for copying
       And a ssh command "touch /home/vagrant/copy-out-after-test-file"
       And an extra argument "--rsync"
      When the vm runs to completion
      Then the return code is 0
       And the file "artifacts/copy-out-after-test-file" exists
 
-  Scenario: Copy in a symbolic link using rsync
+    Examples: Image Types
+      | image_type |
+      | dedicated  |
+      | same       |
+
+  Scenario Outline: Copy in a symbolic link using rsync
     Given a transient run command
       And an http alpine disk image
       And a symbolic link "artifacts/symlink" to "/etc/hostname"
       And a guest directory: "/home/vagrant/"
       And the test file is copied to the guest directory before starting
+      And using the "<image_type>" image for copying
       And a ssh command "test -L /home/vagrant/symlink"
       And an extra argument "--rsync"
      When the vm runs to completion
      Then the return code is 0
+
+    Examples: Image Types
+      | image_type |
+      | dedicated  |
+      | same       |

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -225,7 +225,7 @@ def step_impl(context, image):
 def step_impl(context):
     context.vm_config[
         "transient-image"
-    ] = "alpine_rel3,http=https://github.com/ALSchwalm/transient-baseimages/releases/download/5/alpine-3.13.qcow2.xz"
+    ] = "alpine_rel3,http=https://github.com/ALSchwalm/transient-baseimages/releases/download/6/alpine-3.13.qcow2.xz"
 
 
 @given("an http centos disk image")
@@ -334,6 +334,13 @@ def step_impl(context):
         context.vm_config["guest-path"], context.vm_config["host-directory"]
     )
     context.vm_config["transient-args"].extend(["--copy-out-after", directory_mapping])
+
+
+@given('using the "{image_type}" image for copying')
+def step_impl(context, image_type):
+    assert image_type in ("same", "dedicated"), repr(image_type)
+    if image_type == "same":
+        context.vm_config["transient-args"].extend(["--direct-copy"])
 
 
 @given('a qemu flag "{flag}"')

--- a/transient/args.py
+++ b/transient/args.py
@@ -175,6 +175,12 @@ def define_parsers(include_defaults: bool) -> Tuple[argparse.ArgumentParser, ...
         help="The maximum time to wait for a copy-in-before or copy-out-after operation to complete",
     )
     common_oneshot_parser.add_argument(
+        "--direct-copy",
+        action="store_const",
+        const=True,
+        help="Transfier files specified via --copy-in-before or --copy-in-after directly to the VM, instead of a background 'builder' VM",
+    )
+    common_oneshot_parser.add_argument(
         "--rsync",
         action="store_const",
         const=True,

--- a/transient/configuration.py
+++ b/transient/configuration.py
@@ -276,3 +276,10 @@ def config_requires_ssh_console(config: Union[RunConfig, CreateConfig]) -> bool:
         or config.ssh_command is not None
         or config.ssh_with_serial is True
     )
+
+
+def config_wants_rsync_transfer(config: Union[RunConfig, BuildConfig]) -> bool:
+    if config.rsync is not None:
+        assert isinstance(config.rsync, bool)
+        return config.rsync is True
+    return False

--- a/transient/editor.py
+++ b/transient/editor.py
@@ -283,16 +283,21 @@ class ImageEditor:
             return None, None
 
     def copy_in(self, host_path: str, guest_path: str) -> None:
-        transfer = ssh.rsync if self.rsync is True else ssh.scp
-        transfer(
-            host_path, utils.join_absolute_paths("/mnt", guest_path), self.ssh_config
+        use_rsync = self.rsync is True
+        ssh.transfer(
+            host_path,
+            utils.join_absolute_paths("/mnt", guest_path),
+            ssh_config=self.ssh_config,
+            copy_from=False,
+            use_rsync=use_rsync,
         )
 
     def copy_out(self, guest_path: str, host_path: str) -> None:
-        transfer = ssh.rsync if self.rsync is True else ssh.scp
-        transfer(
+        use_rsync = self.rsync is True
+        ssh.transfer(
             utils.join_absolute_paths("/mnt", guest_path),
             host_path,
-            self.ssh_config,
+            ssh_config=self.ssh_config,
             copy_from=True,
+            use_rsync=use_rsync,
         )

--- a/transient/ssh.py
+++ b/transient/ssh.py
@@ -298,3 +298,19 @@ def rsync(
             capture_stdout=capture_stdout,
             capture_stderr=capture_stderr,
         )
+
+
+def transfer(
+    host_path: str,
+    guest_path: str,
+    ssh_config: SshConfig,
+    copy_from: bool,
+    use_rsync: bool,
+) -> None:
+    func = rsync if use_rsync is True else scp
+    logging.debug(
+        "Transfer host_path={} guest_path={} copy_from={} func={}".format(
+            host_path, guest_path, copy_from, func
+        )
+    )
+    func(host_path, guest_path, ssh_config, copy_from)


### PR DESCRIPTION

    When --copy-using-image is specified, copy operations
    will be done using the main QEMU session instead of separate ones.
    
    This avoids the time spent starting up separate QEMU sessions before/after
    the main one to do file copying.
    
