### PR TITLE
Ensure that qemu dies when we tell it to.

### DIFF
--- a/test/unit/test_qemu.py
+++ b/test/unit/test_qemu.py
@@ -1,0 +1,34 @@
+from transient import qemu
+import signal
+
+
+def test_qemu_terminate():
+    class StalledQemuRunner(qemu.QemuRunner):
+        def _make_command_line(self):
+            return ["sleep", "100000"]
+
+    runner = StalledQemuRunner([])
+    runner.start()
+    assert runner.is_running()
+    runner.terminate()
+    runner.wait(timeout=10)
+    assert runner.returncode() == -signal.SIGTERM
+
+
+def test_qemu_terminate_kill_after():
+    class StalledQemuRunner(qemu.QemuRunner):
+        def _make_command_line(self):
+            return ["sleep", "100000"]
+
+        @staticmethod
+        def _qemu_preexec():
+            # dispositions of ignored signals are inherited across exec
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+    runner = StalledQemuRunner([])
+    runner.start()
+    assert runner.is_running()
+    runner.terminate()
+    assert runner.is_running()
+    runner.terminate(kill_after=1)
+    assert runner.returncode() == -signal.SIGKILL

--- a/transient/transient.py
+++ b/transient/transient.py
@@ -462,7 +462,7 @@ class TransientVm:
 
                 # If we didn't reach the expected shutdown, this will terminte
                 # the VM. Otherwise, this does nothing.
-                self.qemu_runner.terminate()
+                self.qemu_runner.terminate(kill_after=self.config.shutdown_timeout)
 
             # Note that we always return the SSH exit code, even if the guest failed to
             # shut down. This ensures the shutdown_timeout=0 case is handled as expected.


### PR DESCRIPTION
Fixes an error where an (expected) kernel panic on shutdown caused Qemu to not exit immediately on receipt of SIGTERM in CI. As a result, `-copy-out-after` was unable to copy files because the disk was still in use, and the transient process crashed.