### PR TITLE
Suppressed a minor set of warnings when using --copy-in-before

### DIFF
--- a/transient/editor.py
+++ b/transient/editor.py
@@ -173,11 +173,12 @@ class ImageEditor:
                         f"mount -t {fstype} {path} /mnt > /dev/null",
                         "[ -f /mnt/etc/fstab ]",
                     ],
+                    capture_stderr=True,
                 )
                 return
             except Exception as e:
                 logging.debug(f"Failed to read /etc/fstab from {path}: {e}")
-                self.run_command_in_guest("umount /mnt > /dev/null", allowfail=True)
+                self.run_command_in_guest("umount /mnt > /dev/null 2>&1", allowfail=True)
                 continue
         raise RuntimeError("Unable to locate /etc/fstab")
 


### PR DESCRIPTION
Judging by the redirect to /dev/null, these errors were intended to be suppressed anyway, but stderr never got redirected.
This caused the following warnings when the VM I'm using runs with `--copy-in-before`:
```
mount: /mnt: operation failed: Invalid argument.
umount: /mnt: not mounted.
mount: /mnt: unknown filesystem type 'LVM2_member'.
umount: /mnt: not mounted.
```

Adding `-v` indicated that Transient was cycling through `swap` and `LVM2_member` partitions first while searching for `/etc/fstab`, for which the failures had no effect on successfully running the VM.